### PR TITLE
changed currentUser state to {}

### DIFF
--- a/client/src/components/layout/PersistedMarkers.js
+++ b/client/src/components/layout/PersistedMarkers.js
@@ -4,8 +4,8 @@ import getCurrentUser from "../../services/getCurrentUser"
 
 const PersistedMarkers = ({ fetchedMarkers, panTo, markerIcon }) => {
   const [fetchedSelected, setFetchedSelected] = useState(null)
-
-  const [currentUser, setCurrentUser] = useState(undefined);
+  const [currentUser, setCurrentUser] = useState({});
+  
   useEffect(() => {
     getCurrentUser()
       .then((user) => {


### PR DESCRIPTION
- currentUser id default state was undefined, and it was giving error messages when loading the map at times
- updated the default state to {} to avoid error: "cannot find id of undefined"