### PR TITLE
marker display fix

### DIFF
--- a/client/src/components/layout/IndexMarkers.js
+++ b/client/src/components/layout/IndexMarkers.js
@@ -161,7 +161,7 @@ const IndexMarkers = ({ setMarker, marker, panTo }) => {
       <Marker 
       key={`${marker.lat} - ${marker.lng}`}
       position={{ lat: marker.lat, lng: marker.lng }}
-      icon={markerIcon("blue")}
+      icon={markerIcon("blue", 0.6)}
       onClick = {() => {
         setSelected(marker)
         setErrors({})


### PR DESCRIPTION
- minor marker display fix
- blue marker was not showing when clicking on the map because fillOpacity wasn't designated